### PR TITLE
Bug fixed https://jira.tid.es/browse/OWD-1757

### DIFF
--- a/apps/homescreen/js/grid.js
+++ b/apps/homescreen/js/grid.js
@@ -266,7 +266,7 @@ if (!owd.GridManager) {
       window.removeEventListener(endEvent, owd.GridManager);
 
       if (dragger.dragging) {
-        dragger.stop(evt.target);
+        dragger.stop();
         delete container.dataset.transitioning;
       } else {
         var difX = status.cCoords.x - status.iCoords.x;
@@ -600,18 +600,6 @@ if (!owd.GridManager) {
       },
 
       /*
-       * Detects when the end-users move an icon to another page but they
-       * drop the icon on the edge. It should be placed as first child
-       *
-       * @param {Object} DOMElement behind draggable icon
-       */
-      checkDropOnTheEdge: function(overlapElem) {
-        if (overlapElem.className === 'page') {
-          pageHelper.getCurrent().moveIconToFirstChild(draggableIcon);
-        }
-      },
-
-      /*
        * Detects when users are touching on the limits of a page during
        * the dragging. So we can change the current page and navigate
        * to prev/next page depending on the position.
@@ -666,10 +654,9 @@ if (!owd.GridManager) {
        * there is overflow or not in a page and removes the last page when
        * is empty
        */
-      stop: function(overlapElem) {
+      stop: function() {
         clearTimeout(this.translatingTimeout);
         this.isTranslatingPages = false;
-        this.checkDropOnTheEdge(overlapElem);
         this.dragging = false;
         draggableIcon.onDragStop();
         // When the drag&drop is finished we need to check empty pages and overflows

--- a/apps/homescreen/js/page.js
+++ b/apps/homescreen/js/page.js
@@ -311,13 +311,26 @@ if (!owd.Page) {
     * @param{Object} icon object
     */
     prependIcon: function(icon) {
-      var len = this.olist.length;
-      if (len > 0) {
-        this.olist.insertBefore(icon.getListItem(), this.olist.firstChild);
+      var olist = this.olist;
+      if (olist.childNodes.length > 0) {
+        olist.insertBefore(icon.getListItem(), this.olist.firstChild);
       } else {
-        this.olist.appendChild(icon.getListItem());
+        olist.appendChild(icon.getListItem());
       }
       this.licons[icon.descriptor.origin] = icon;
+    },
+
+   /*
+    * Moves an icon to the first position
+    *
+    * @param{Object} icon object
+    */
+    moveIconToFirstChild: function(icon) {
+      var olist = this.olist;
+      if (olist.childNodes.length > 0) {
+        olist.insertBefore(icon.getListItem(), olist.firstChild);
+      }
+
     },
 
    /*


### PR DESCRIPTION
The application is moved to new desktop.

When the end-user move an icon from one desktop to another and leave the icon on the edge, the icon is created in a new desktop. For instance if I leave the icon on the edge of the second desktop, the icon is created in the third desktop.
